### PR TITLE
feat: support MST 5, 6, and 7 as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mst-middlewares",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "The MST package ships with some prebuilt middlewares, which serves mainly as examples on how to write your own middleware. The source of each middleware can be found in this github directory, you are encouraged to read them!",
   "main": "dist/mst-middlewares.js",
   "umd:main": "dist/mst-middlewares.umd.js",
@@ -51,7 +51,7 @@
     "typescript": "3.9.4"
   },
   "peerDependencies": {
-    "mobx-state-tree": "^5.0.0"
+    "mobx-state-tree": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "files": [
     "dist/"

--- a/yarn.lock
+++ b/yarn.lock
@@ -635,7 +635,7 @@
     "@babel/parser" "^7.1.0"
     "@babel/types" "^7.0.0"
 
-"@types/babel__traverse@*", "@types/babel__traverse@7.0.6", "@types/babel__traverse@^7.0.4", "@types/babel__traverse@^7.0.6":
+"@types/babel__traverse@*", "@types/babel__traverse@^7.0.4", "@types/babel__traverse@^7.0.6":
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.0.6.tgz#328dd1a8fc4cfe3c8458be9477b219ea158fd7b2"
   integrity sha512-XYVgHF2sQ0YblLRMLNPB3CkFMewzFmlDsH/TneZFHUXDlABQgh88uOxuez7ZcXxayLFrqLwtDH1t+FmlFwNZxw==


### PR DESCRIPTION
Closes #20 by supporting MST v6 and also MST v7 since [we are preparing for a v7](https://github.com/mobxjs/mobx-state-tree/releases/tag/v7.0.0-pre.1)